### PR TITLE
Fix: Content-Type check & Block Kit Loop

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -4,13 +4,17 @@ import json
 def request(flow):
     if "content-type" not in flow.request.headers:
         return
-    if "application/json" in flow.request.headers["content-type"]:
-        slack_json = json.loads(flow.request.text)
+    if "application/json" in flow.request.headers["content-type"] or "text/plain" in flow.request.headers["content-type"]:
+        slack_json = json.loads(flow.request.text, strict=False)
         if "blocks" in slack_json:
-            slack_text = slack_json['blocks'][0]['text']['text'].replace(">>>","")
+            slack_text = ""
             if len(slack_json['blocks']) > 1:
                 for block in slack_json['blocks']:
-                    slack_text += "\n" + slack_json['blocks'][block]['text']['text']
+                    if "text" in block:
+                        slack_text += block['text']['text']
+                    elif "fields" in block:
+                        for field in block['fields']:
+                            slack_text += "\n" + field['text']
             mattermost_json = '{"text": "' + slack_text + '"}'
         else:
             mattermost_json = slack_json


### PR DESCRIPTION
Last year we came across your project and used it to help us integrate Accelq with Mattermost as they use block kit format. They weren't open to making changes to their format. 

We where able to deploy this tool to Kuberetes for any requests from Accelq.

We found that it needed some tweaks for it to work. I removed the extra stuff we had to format the Accelq messages so I could PR it back.

Thanks for making this!

Here are the changes that should help anyone else wanting to use this. 